### PR TITLE
Add users page

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,13 +1,7 @@
 <x-app-layout>
-    <x-slot name="header">
-        <flux:heading size="xl" level="2">{{ __('Dashboard') }}</flux:heading>
-    </x-slot>
-
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <flux:card>
-                <flux:heading>{{ __("You're logged in!") }}</flux:heading>
-            </flux:card>
-        </div>
-    </div>
+    <flux:main class="space-y-6">
+        <flux:card>
+            <flux:heading>{{ __("You're logged in!") }}</flux:heading>
+        </flux:card>
+    </flux:main>
 </x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -27,6 +27,7 @@
 
         <flux:navlist variant="outline">
             <flux:navlist.item icon="home" :href="route('dashboard')">{{ __('Home') }}</flux:navlist.item>
+            <flux:navlist.item icon="users" :href="route('users')">{{ __('Users') }}</flux:navlist.item>
         </flux:navlist>
 
         <flux:spacer />
@@ -58,9 +59,7 @@
         </flux:dropdown>
     </flux:header>
 
-    <flux:main>
-        {{ $slot }}
-    </flux:main>
+    {{ $slot }}
 
     @fluxScripts
     @vite('resources/js/app.js')

--- a/resources/views/livewire/pages/users.blade.php
+++ b/resources/views/livewire/pages/users.blade.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Validation\Rule;
+
+use function Livewire\Volt\{computed, layout, state, usesPagination};
+
+layout('layouts.app');
+usesPagination();
+
+state([
+    'sortBy',
+    'sortDirection' => 'desc',
+    'editingUser',
+    'name' => '',
+    'email' => '',
+]);
+
+$edit = function ($id) {
+    $user = $this->users->firstWhere('id', $id);
+
+    $this->editingUser = $user;
+    $this->name = $user->name;
+    $this->email = $user->email;
+
+    $this->modal('edit-user')->show();
+};
+
+$save = function () {
+    $validated = $this->validate([
+        'name' => ['required', 'string', 'max:255'],
+        'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->editingUser->id)],
+    ]);
+
+    $this->editingUser->fill($validated);
+
+    if ($this->editingUser->isDirty('email')) {
+        $this->editingUser->email_verified_at = null;
+    }
+
+    $this->editingUser->save();
+
+    $this->reset('editingUser', 'name', 'email');
+    $this->modal('edit-user')->close();
+};
+
+$sort = function ($column) {
+    if ($this->sortBy === $column && $this->sortDirection === 'asc') {
+        $this->reset('sortBy', 'sortDirection');
+    } else if ($this->sortBy === $column) {
+        $this->sortDirection = 'asc';
+    } else {
+        $this->sortBy = $column;
+        $this->sortDirection = 'desc';
+    }
+};
+
+$users = computed(function () {
+    return User::query()
+        ->tap(fn ($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
+        ->paginate(10);
+})
+
+?>
+
+<flux:main class="space-y-6">
+    <flux:heading size="xl" level="1">{{ __('Users') }}</flux:heading>
+
+    <flux:table :paginate="$this->users">
+        <flux:columns>
+            <flux:column>ID</flux:column>
+            <flux:column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:column>
+            <flux:column sortable :sorted="$sortBy === 'email'" :direction="$sortDirection" wire:click="sort('email')">Email</flux:column>
+        </flux:columns>
+
+        <flux:rows>
+            @foreach ($this->users as $user)
+                <flux:row :key="$user->id">
+                    <flux:cell>{{ $user->id }}</flux:cell>
+                    <flux:cell>{{ $user->name }}</flux:cell>
+                    <flux:cell>{{ $user->email }}</flux:cell>
+
+                    <flux:cell>
+                        <flux:dropdown>
+                            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
+
+                            <flux:menu>
+                                <flux:menu.item icon="pencil-square" wire:click="edit({{ $user->id }})">Edit</flux:menu.item>
+                                <flux:menu.item variant="danger" icon="trash">Delete</flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    </flux:cell>
+                </flux:row>
+            @endforeach
+        </flux:rows>
+    </flux:table>
+
+    <flux:modal name="edit-user" variant="flyout">
+        <form wire:submit="save" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Update User</flux:heading>
+                <flux:subheading>Make changes to a user's details.</flux:subheading>
+            </div>
+
+            <flux:input wire:model="name" :label="__('Name')" type="text" required autocomplete="name" />
+            <flux:input wire:model="email" :label="__('Email')" type="email" required autocomplete="email" />
+
+            <div class="flex">
+                <flux:spacer />
+
+                <flux:button type="submit" variant="primary">Save changes</flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</flux:main>

--- a/resources/views/livewire/pages/users.blade.php
+++ b/resources/views/livewire/pages/users.blade.php
@@ -16,6 +16,12 @@ state([
     'email' => '',
 ]);
 
+$delete = function ($id) {
+    $this->users->firstWhere('id', $id)->delete();
+
+    unset($this->users);
+};
+
 $edit = function ($id) {
     $user = $this->users->firstWhere('id', $id);
 
@@ -86,7 +92,7 @@ $users = computed(function () {
 
                             <flux:menu>
                                 <flux:menu.item icon="pencil-square" wire:click="edit({{ $user->id }})">Edit</flux:menu.item>
-                                <flux:menu.item variant="danger" icon="trash">Delete</flux:menu.item>
+                                <flux:menu.item variant="danger" icon="trash" wire:click="delete({{ $user->id }})">Delete</flux:menu.item>
                             </flux:menu>
                         </flux:dropdown>
                     </flux:cell>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,15 +1,15 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Volt\Volt;
 
 Route::view('/', 'welcome');
 
-Route::view('dashboard', 'dashboard')
-    ->middleware(['auth', 'verified'])
-    ->name('dashboard');
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::view('dashboard', 'dashboard')->name('dashboard');
+    Route::view('profile', 'profile')->name('profile');
 
-Route::view('profile', 'profile')
-    ->middleware(['auth'])
-    ->name('profile');
+    Volt::route('/users', 'pages.users')->name('users');
+});
 
 require __DIR__ . '/auth.php';

--- a/tests/Feature/Livewire/Pages/UsersTest.php
+++ b/tests/Feature/Livewire/Pages/UsersTest.php
@@ -42,3 +42,34 @@ test('can sort columns', function () {
         // assert names are back in default order
         ->assertSeeInOrder(['Ashar', 'Velvet', 'Andy', 'Geo']);
 });
+
+test('can edit user', function () {
+    $user = User::factory()->create([
+        'name' => 'Kouzuki Oden',
+        'email' => 'oden@whitebeard.pirate',
+    ]);
+
+    Volt::test('pages.users')
+        ->call('edit', $user->id)
+        ->assertSet('name', 'Kouzuki Oden')
+        ->assertSet('email', 'oden@whitebeard.pirate')
+        ->set('email', 'oden@rodger.pirate')
+        ->call('save');
+
+    expect($user->fresh()->email)->toBe('oden@rodger.pirate');
+});
+
+test('can delete user', function () {
+    $user = User::factory()->create([
+        'name' => 'Kouzuki Oden',
+        'email' => 'oden@whitebeard.pirate',
+    ]);
+
+    Volt::test('pages.users')
+        ->call('delete', $user->id);
+
+    $this->assertDatabaseMissing('users', [
+        'name' => 'Kouzuki Oden',
+        'email' => 'oden@whitebeard.pirate',
+    ]);
+});

--- a/tests/Feature/Livewire/Pages/UsersTest.php
+++ b/tests/Feature/Livewire/Pages/UsersTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Livewire\Volt\Volt;
+
+test('can view page', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get('/users')
+        ->assertOk()
+        ->assertSee('Users');
+});
+
+test('can view component', function () {
+    Volt::test('pages.users')
+        ->assertSee('Users');
+});
+
+test('can sort columns', function () {
+    User::factory()
+        ->count(4)
+        ->state(new Sequence(
+            ['name' => 'Ashar'],
+            ['name' => 'Velvet'],
+            ['name' => 'Andy'],
+            ['name' => 'Geo'],
+        ))
+        ->create();
+
+    Volt::test('pages.users')
+        // assert names are in creation order
+        ->assertSeeInOrder(['Ashar', 'Velvet', 'Andy', 'Geo'])
+        ->call('sort', 'name')
+        // assert names are in descending order
+        ->assertSeeInOrder(['Velvet', 'Geo', 'Ashar', 'Andy'])
+        ->call('sort', 'name')
+        // assert names are in ascending order
+        ->assertSeeInOrder(['Andy', 'Ashar', 'Geo', 'Velvet'])
+        ->call('sort', 'name')
+        // assert names are back in default order
+        ->assertSeeInOrder(['Ashar', 'Velvet', 'Andy', 'Geo']);
+});


### PR DESCRIPTION
This PR:
- Adds a page to view all users
- Sortable `name` and `email` columns
- User can be edited via a flyout modal
- User can be deleted 