### PR TITLE
Add location page

### DIFF
--- a/app/Livewire/Pages/Inventory/Locations.php
+++ b/app/Livewire/Pages/Inventory/Locations.php
@@ -39,18 +39,22 @@ class Locations extends Component
         $this->editingLocation = $this->locations->firstWhere('id', $id);
         $this->name = $this->editingLocation->name;
 
-        $this->modal('edit-location')->show();
+        $this->modal('location-form')->show();
     }
 
-    public function store()
+    public function save()
     {
         $this->validate();
 
-        Location::create(['name' => $this->name]);
+        if ($this->editingLocation) {
+            $this->editingLocation->update(['name' => $this->name]);
+        } else {
+            Location::create(['name' => $this->name]);
+        }
 
         $this->reset('name');
         unset($this->locations);
-        $this->modal('create-location')->close();
+        $this->modal('location-form')->close();
     }
 
     public function sort($column)
@@ -63,16 +67,5 @@ class Locations extends Component
             $this->sortBy = $column;
             $this->sortDirection = 'desc';
         }
-    }
-
-    public function update()
-    {
-        $this->validate();
-
-        $this->editingLocation->update(['name' => $this->name]);
-
-        $this->reset('name');
-        unset($this->locations);
-        $this->modal('edit-location')->close();
     }
 }

--- a/app/Livewire/Pages/Inventory/Locations.php
+++ b/app/Livewire/Pages/Inventory/Locations.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Livewire\Pages\Inventory;
+
+use App\Models\Location;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Locations extends Component
+{
+    use WithPagination;
+
+    public $sortBy = '';
+    public $sortDirection = 'desc';
+
+    #[Layout('layouts.app')]
+    public function render()
+    {
+        return view('livewire.pages.inventory.locations');
+    }
+
+    #[Computed]
+    public function locations()
+    {
+        return Location::query()
+            ->when($this->sortBy, fn ($query) => $query->orderBy($this->sortBy, $this->sortDirection))
+            ->paginate(10);
+    }
+
+    public function sort($column) {
+        if ($this->sortBy === $column && $this->sortDirection === 'asc') {
+            $this->reset('sortBy', 'sortDirection');
+        } else if ($this->sortBy === $column) {
+            $this->sortDirection = 'asc';
+        } else {
+            $this->sortBy = $column;
+            $this->sortDirection = 'desc';
+        }
+    }
+}

--- a/app/Livewire/Pages/Inventory/Locations.php
+++ b/app/Livewire/Pages/Inventory/Locations.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Pages\Inventory;
 use App\Models\Location;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\Validate;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -12,6 +13,8 @@ class Locations extends Component
 {
     use WithPagination;
 
+    #[Validate('required|min:3')]
+    public $name = '';
     public $sortBy = '';
     public $sortDirection = 'desc';
 
@@ -29,10 +32,21 @@ class Locations extends Component
             ->paginate(10);
     }
 
-    public function sort($column) {
+    public function store()
+    {
+        $this->validate();
+
+        Location::create(['name' => $this->name]);
+
+        $this->reset('name');
+        unset($this->locations);
+    }
+
+    public function sort($column)
+    {
         if ($this->sortBy === $column && $this->sortDirection === 'asc') {
             $this->reset('sortBy', 'sortDirection');
-        } else if ($this->sortBy === $column) {
+        } elseif ($this->sortBy === $column) {
             $this->sortDirection = 'asc';
         } else {
             $this->sortBy = $column;

--- a/app/Livewire/Pages/Inventory/Locations.php
+++ b/app/Livewire/Pages/Inventory/Locations.php
@@ -19,6 +19,8 @@ class Locations extends Component
     public $name = '';
     public $editingLocation = null;
 
+    public $perPage = 10;
+    public $search = '';
     public $sortBy = '';
     public $sortDirection = 'desc';
 
@@ -33,7 +35,8 @@ class Locations extends Component
     {
         return Location::query()
             ->when($this->sortBy, fn ($query) => $query->orderBy($this->sortBy, $this->sortDirection))
-            ->paginate(10);
+            ->when($this->search, fn ($query) => $query->where('name', 'like', '%' . $this->search . '%'))
+            ->paginate($this->perPage);
     }
 
     public function delete($id)

--- a/app/Livewire/Pages/Inventory/Locations.php
+++ b/app/Livewire/Pages/Inventory/Locations.php
@@ -2,7 +2,9 @@
 
 namespace App\Livewire\Pages\Inventory;
 
+use App\Models\Bin;
 use App\Models\Location;
+use App\Models\Thing;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Validate;
@@ -32,6 +34,17 @@ class Locations extends Component
         return Location::query()
             ->when($this->sortBy, fn ($query) => $query->orderBy($this->sortBy, $this->sortDirection))
             ->paginate(10);
+    }
+
+    public function delete($id)
+    {
+        $location = $this->locations->firstWhere('id', $id);
+
+        Bin::where('location_id', $location->id)->update(['location_id' => null]);
+        Thing::where('location_id', $location->id)->update(['location_id' => null]);
+
+        $location->delete();
+        unset($this->locations);
     }
 
     public function edit($id)

--- a/app/Livewire/Pages/Inventory/Locations.php
+++ b/app/Livewire/Pages/Inventory/Locations.php
@@ -15,6 +15,8 @@ class Locations extends Component
 
     #[Validate('required|min:3')]
     public $name = '';
+    public $editingLocation = null;
+
     public $sortBy = '';
     public $sortDirection = 'desc';
 
@@ -32,6 +34,14 @@ class Locations extends Component
             ->paginate(10);
     }
 
+    public function edit($id)
+    {
+        $this->editingLocation = $this->locations->firstWhere('id', $id);
+        $this->name = $this->editingLocation->name;
+
+        $this->modal('edit-location')->show();
+    }
+
     public function store()
     {
         $this->validate();
@@ -40,6 +50,7 @@ class Locations extends Component
 
         $this->reset('name');
         unset($this->locations);
+        $this->modal('create-location')->close();
     }
 
     public function sort($column)
@@ -52,5 +63,16 @@ class Locations extends Component
             $this->sortBy = $column;
             $this->sortDirection = 'desc';
         }
+    }
+
+    public function update()
+    {
+        $this->validate();
+
+        $this->editingLocation->update(['name' => $this->name]);
+
+        $this->reset('name');
+        unset($this->locations);
+        $this->modal('edit-location')->close();
     }
 }

--- a/resources/views/livewire/pages/inventory/locations.blade.php
+++ b/resources/views/livewire/pages/inventory/locations.blade.php
@@ -1,38 +1,50 @@
 <flux:main class="space-y-6">
-    <div class="flex">
+    <header class="flex">
         <flux:heading size="xl" level="1">{{ __('Locations') }}</flux:heading>
         <flux:spacer />
         <flux:modal.trigger name="create-location">
             <flux:button>Create</flux:button>
         </flux:modal.trigger>
-    </div>
+    </header>
 
-    <flux:table :paginate="$this->locations">
-        <flux:columns>
-            <flux:column>ID</flux:column>
-            <flux:column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:column>
-        </flux:columns>
+    <section>
+        <div class="flex justify-between gap-8 mb-2">
+            <flux:input size="sm" wire:model.live="search" icon="magnifying-glass" class="max-w-sm" placeholder="Search locations" />
 
-        <flux:rows>
-            @foreach ($this->locations as $location)
-                <flux:row :key="$location->id">
-                    <flux:cell>{{ $location->id }}</flux:cell>
-                    <flux:cell>{{ $location->name }}</flux:cell>
+            <flux:select size="sm" wire:model.blur="perPage" class="max-w-20" placeholder="Per Page">
+                <flux:option>5</flux:option>
+                <flux:option>10</flux:option>
+                <flux:option>25</flux:option>
+                <flux:option>50</flux:option>
+            </flux:select>
+        </div>
+        <flux:table :paginate="$this->locations">
+            <flux:columns>
+                <flux:column>ID</flux:column>
+                <flux:column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:column>
+            </flux:columns>
 
-                    <flux:cell>
-                        <flux:dropdown>
-                            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
+            <flux:rows>
+                @foreach ($this->locations as $location)
+                    <flux:row :key="$location->id">
+                        <flux:cell>{{ $location->id }}</flux:cell>
+                        <flux:cell>{{ $location->name }}</flux:cell>
 
-                            <flux:menu>
-                                <flux:menu.item icon="pencil-square" wire:click="edit({{ $location->id }})">Edit</flux:menu.item>
-                                <flux:menu.item variant="danger" icon="trash" wire:click="delete({{ $location->id }})">Delete</flux:menu.item>
-                            </flux:menu>
-                        </flux:dropdown>
-                    </flux:cell>
-                </flux:row>
-            @endforeach
-        </flux:rows>
-    </flux:table>
+                        <flux:cell>
+                            <flux:dropdown>
+                                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
+
+                                <flux:menu>
+                                    <flux:menu.item icon="pencil-square" wire:click="edit({{ $location->id }})">Edit</flux:menu.item>
+                                    <flux:menu.item variant="danger" icon="trash" wire:click="delete({{ $location->id }})">Delete</flux:menu.item>
+                                </flux:menu>
+                            </flux:dropdown>
+                        </flux:cell>
+                    </flux:row>
+                @endforeach
+            </flux:rows>
+        </flux:table>
+    </section>
 
     <flux:modal name="location-form" variant="flyout">
         <form wire:submit="save" class="space-y-6">

--- a/resources/views/livewire/pages/inventory/locations.blade.php
+++ b/resources/views/livewire/pages/inventory/locations.blade.php
@@ -50,4 +50,21 @@
             </div>
         </form>
     </flux:modal>
+
+    <flux:modal name="edit-location" variant="flyout">
+        <form wire:submit="update" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Edit Location</flux:heading>
+                <flux:subheading>A place or room that can store bins and things.</flux:subheading>
+            </div>
+
+            <flux:input wire:model="name" :label="__('Name')" />
+
+            <div class="flex">
+                <flux:spacer />
+
+                <flux:button type="submit" variant="primary">Save changes</flux:button>
+            </div>
+        </form>
+    </flux:modal>
 </flux:main>

--- a/resources/views/livewire/pages/inventory/locations.blade.php
+++ b/resources/views/livewire/pages/inventory/locations.blade.php
@@ -1,5 +1,11 @@
 <flux:main class="space-y-6">
-    <flux:heading size="xl" level="1">{{ __('Locations') }}</flux:heading>
+    <div class="flex">
+        <flux:heading size="xl" level="1">{{ __('Locations') }}</flux:heading>
+        <flux:spacer />
+        <flux:modal.trigger name="create-location">
+            <flux:button>Create</flux:button>
+        </flux:modal.trigger>
+    </div>
 
     <flux:table :paginate="$this->locations">
         <flux:columns>
@@ -27,4 +33,21 @@
             @endforeach
         </flux:rows>
     </flux:table>
+
+    <flux:modal name="create-location" variant="flyout">
+        <form wire:submit="store" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Create Location</flux:heading>
+                <flux:subheading>A place or room that can store bins and things.</flux:subheading>
+            </div>
+
+            <flux:input wire:model="name" :label="__('Name')" />
+
+            <div class="flex">
+                <flux:spacer />
+
+                <flux:button type="submit" variant="primary">Save changes</flux:button>
+            </div>
+        </form>
+    </flux:modal>
 </flux:main>

--- a/resources/views/livewire/pages/inventory/locations.blade.php
+++ b/resources/views/livewire/pages/inventory/locations.blade.php
@@ -1,0 +1,30 @@
+<flux:main class="space-y-6">
+    <flux:heading size="xl" level="1">{{ __('Locations') }}</flux:heading>
+
+    <flux:table :paginate="$this->locations">
+        <flux:columns>
+            <flux:column>ID</flux:column>
+            <flux:column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:column>
+        </flux:columns>
+
+        <flux:rows>
+            @foreach ($this->locations as $location)
+                <flux:row :key="$location->id">
+                    <flux:cell>{{ $location->id }}</flux:cell>
+                    <flux:cell>{{ $location->name }}</flux:cell>
+
+                    <flux:cell>
+                        <flux:dropdown>
+                            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
+
+                            <flux:menu>
+                                <flux:menu.item icon="pencil-square" wire:click="edit({{ $location->id }})">Edit</flux:menu.item>
+                                <flux:menu.item variant="danger" icon="trash" wire:click="delete({{ $location->id }})">Delete</flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    </flux:cell>
+                </flux:row>
+            @endforeach
+        </flux:rows>
+    </flux:table>
+</flux:main>

--- a/resources/views/livewire/pages/inventory/locations.blade.php
+++ b/resources/views/livewire/pages/inventory/locations.blade.php
@@ -34,27 +34,10 @@
         </flux:rows>
     </flux:table>
 
-    <flux:modal name="create-location" variant="flyout">
-        <form wire:submit="store" class="space-y-6">
+    <flux:modal name="location-form" variant="flyout">
+        <form wire:submit="save" class="space-y-6">
             <div>
-                <flux:heading size="lg">Create Location</flux:heading>
-                <flux:subheading>A place or room that can store bins and things.</flux:subheading>
-            </div>
-
-            <flux:input wire:model="name" :label="__('Name')" />
-
-            <div class="flex">
-                <flux:spacer />
-
-                <flux:button type="submit" variant="primary">Save changes</flux:button>
-            </div>
-        </form>
-    </flux:modal>
-
-    <flux:modal name="edit-location" variant="flyout">
-        <form wire:submit="update" class="space-y-6">
-            <div>
-                <flux:heading size="lg">Edit Location</flux:heading>
+                <flux:heading size="lg">{{ $this->editingLocation ? 'Edit' : 'Create' }} Location</flux:heading>
                 <flux:subheading>A place or room that can store bins and things.</flux:subheading>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Livewire\Pages\Inventory\Locations;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 
@@ -8,6 +9,8 @@ Route::view('/', 'welcome');
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::view('dashboard', 'dashboard')->name('dashboard');
     Route::view('profile', 'profile')->name('profile');
+
+    Route::get('inventory/locations', Locations::class)->name('inventory.locations');
 
     Volt::route('/users', 'pages.users')->name('users');
 });

--- a/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
+++ b/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
@@ -66,7 +66,20 @@ test('can create location', function () {
     ]);
 });
 
-test('can edit location')->todo();
+test('can edit location', function () {
+    $location = Location::factory()->create(['name' => 'Bedroom']);
+
+    Livewire::test(Locations::class)
+        ->assertSee('Bedroom')
+        ->call('edit', $location->id)
+        ->assertSet('name', 'Bedroom')
+        ->set('name', 'Main Bedroom')
+        ->call('update')
+        ->assertSet('name', '');
+
+    expect($location->fresh()->name)->toBe('Main Bedroom');
+});
+
 test('can delete location')->todo();
 test('deleting location updates bins')->todo();
 test('deleting location updates things')->todo();

--- a/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
+++ b/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Livewire\Pages\Inventory\Locations;
+use App\Models\Location;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Livewire\Livewire;
+
+test('can view page', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get('/inventory/locations')
+        ->assertOk()
+        ->assertSee('Locations');
+});
+
+test('can view component', function () {
+    Location::factory()
+        ->count(3)
+        ->state(new Sequence(
+            ['name' => 'Basement'],
+            ['name' => 'Living Room'],
+            ['name' => 'Bedroom'],
+        ))
+        ->create();
+
+    Livewire::test(Locations::class)
+        ->assertSee('Locations')
+        ->assertSee(['Basement', 'Living Room', 'Bedroom']);
+});
+
+test('can sort locations', function () {
+    Location::factory()
+        ->count(3)
+        ->state(new Sequence(
+            ['name' => 'Basement'],
+            ['name' => 'Living Room'],
+            ['name' => 'Bedroom'],
+        ))
+        ->create();
+
+    Livewire::test(Locations::class)
+        // assert names are in creation order
+        ->assertSeeInOrder(['Basement', 'Living Room', 'Bedroom'])
+        ->call('sort', 'name')
+        // assert names are in descending order
+        ->assertSeeInOrder(['Living Room', 'Bedroom', 'Basement'])
+        ->call('sort', 'name')
+        // assert names are in ascending order
+        ->assertSeeInOrder(['Basement', 'Bedroom', 'Living Room'])
+        ->call('sort', 'name')
+        // assert names are back in default order
+        ->assertSeeInOrder(['Basement', 'Living Room', 'Bedroom']);
+});
+
+test('can create location')->todo();
+test('can edit location')->todo();
+test('can delete location')->todo();
+test('deleting location updates bins')->todo();
+test('deleting location updates things')->todo();

--- a/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
+++ b/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
@@ -58,7 +58,7 @@ test('can create location', function () {
     Livewire::test(Locations::class)
         ->assertSee('Create')
         ->set('name', 'Kitchen')
-        ->call('store')
+        ->call('save')
         ->assertSet('name', '');
 
     $this->assertDatabaseHas('locations', [
@@ -74,7 +74,7 @@ test('can edit location', function () {
         ->call('edit', $location->id)
         ->assertSet('name', 'Bedroom')
         ->set('name', 'Main Bedroom')
-        ->call('update')
+        ->call('save')
         ->assertSet('name', '');
 
     expect($location->fresh()->name)->toBe('Main Bedroom');

--- a/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
+++ b/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
@@ -54,7 +54,18 @@ test('can sort locations', function () {
         ->assertSeeInOrder(['Basement', 'Living Room', 'Bedroom']);
 });
 
-test('can create location')->todo();
+test('can create location', function () {
+    Livewire::test(Locations::class)
+        ->assertSee('Create')
+        ->set('name', 'Kitchen')
+        ->call('store')
+        ->assertSet('name', '');
+
+    $this->assertDatabaseHas('locations', [
+        'name' => 'Kitchen',
+    ]);
+});
+
 test('can edit location')->todo();
 test('can delete location')->todo();
 test('deleting location updates bins')->todo();

--- a/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
+++ b/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
@@ -56,6 +56,36 @@ test('can sort locations', function () {
         ->assertSeeInOrder(['Basement', 'Living Room', 'Bedroom']);
 });
 
+test('can search locations', function () {
+    Location::factory()
+        ->count(3)
+        ->state(new Sequence(
+            ['name' => 'Basement'],
+            ['name' => 'Living Room'],
+            ['name' => 'Bedroom'],
+        ))
+        ->create();
+
+    Livewire::test(Locations::class)
+        ->assertSee(['Basement', 'Living Room', 'Bedroom'])
+        ->set('search', 'B')
+        ->assertSee(['Bedroom', 'Basement'])
+        ->set('search', 'Bed')
+        ->assertSee(['Bedroom']);
+});
+
+test('can adjust number per page locations', function () {
+    Location::factory()
+        ->count(10)
+        ->sequence(fn (Sequence $sequence) => ['name' => 'Name ' . $sequence->index + 1])
+        ->create();
+
+    Livewire::test(Locations::class)
+        ->assertSee(['Name 1', 'Name 2', 'Name 3', 'Name 4', 'Name 5', 'Name 6', 'Name 7', 'Name 8', 'Name 9', 'Name 10'])
+        ->set('perPage', 5)
+        ->assertSee(['Name 1', 'Name 2', 'Name 3', 'Name 4', 'Name 5']);
+});
+
 test('can create location', function () {
     Livewire::test(Locations::class)
         ->assertSee('Create')

--- a/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
+++ b/tests/Feature/Livewire/Pages/Inventory/LocationsTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Livewire\Pages\Inventory\Locations;
+use App\Models\Bin;
 use App\Models\Location;
+use App\Models\Thing;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Livewire\Livewire;
@@ -80,6 +82,35 @@ test('can edit location', function () {
     expect($location->fresh()->name)->toBe('Main Bedroom');
 });
 
-test('can delete location')->todo();
-test('deleting location updates bins')->todo();
-test('deleting location updates things')->todo();
+test('can delete location', function () {
+    $location = Location::factory()->create(['name' => 'Bedroom']);
+
+    Livewire::test(Locations::class)
+        ->assertSee('Bedroom')
+        ->call('delete', $location->id)
+        ->assertDontSee('Bedroom');
+
+    $this->assertDatabaseMissing('locations', [
+        'name' => 'Bedroom',
+    ]);
+});
+
+test('deleting location updates bins', function () {
+    $location = Location::factory()->create(['name' => 'Bedroom']);
+    $bin = Bin::factory()->for($location)->create(['name' => 'Sheets Box']);
+
+    Livewire::test(Locations::class)
+        ->call('delete', $location->id);
+
+    expect($bin->fresh()->location_id)->toBeNull();
+});
+
+test('deleting location updates things', function () {
+    $location = Location::factory()->create(['name' => 'Bedroom']);
+    $thing = Thing::factory()->for($location)->create(['name' => 'Light Blue King Sheets']);
+
+    Livewire::test(Locations::class)
+        ->call('delete', $location->id);
+
+    expect($thing->fresh()->location_id)->toBeNull();
+});


### PR DESCRIPTION
Closes #10 

For this new page, I used a class-based Livewire component instead of a Volt component because I wanted to see how it felt to go back to the "old" way of doing Livewire and which one "felt" better to me. The jury is still out, so I think I'll do the Inventory feature this way for consistency.

This PR:
- adds an `Inventory > Locations` page
- list of locations
  - per page editable
  - searchable by name
  - sortable by name
- create location via modal
- edit location via modal
- delete location
  - updates child `bins` to have no `location_id`
  - updates child `things` to have no `location_id`