### PR TITLE
Clean duplicated logic

### DIFF
--- a/app/Livewire/Concerns/WithDataTable.php
+++ b/app/Livewire/Concerns/WithDataTable.php
@@ -2,7 +2,8 @@
 
 namespace App\Livewire\Concerns;
 
-trait WithDataTable {
+trait WithDataTable
+{
     public $perPage = 10;
     public $search = '';
     public $sortBy = '';

--- a/app/Livewire/Concerns/WithDataTable.php
+++ b/app/Livewire/Concerns/WithDataTable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\Concerns;
+
+trait WithDataTable {
+    public $perPage = 10;
+    public $search = '';
+    public $sortBy = '';
+    public $sortDirection = 'desc';
+
+    public function sort($column)
+    {
+        if ($this->sortBy === $column && $this->sortDirection === 'asc') {
+            $this->reset('sortBy', 'sortDirection');
+        } elseif ($this->sortBy === $column) {
+            $this->sortDirection = 'asc';
+        } else {
+            $this->sortBy = $column;
+            $this->sortDirection = 'desc';
+        }
+    }
+}

--- a/app/Livewire/Pages/Inventory/Bins.php
+++ b/app/Livewire/Pages/Inventory/Bins.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Pages\Inventory;
 
+use App\Livewire\Concerns\WithDataTable;
 use App\Models\Bin;
 use App\Models\Location;
 use App\Models\Thing;
@@ -13,6 +14,7 @@ use Livewire\WithPagination;
 
 class Bins extends Component
 {
+    use WithDataTable;
     use WithPagination;
 
     #[Validate('required|min:3')]
@@ -25,11 +27,6 @@ class Bins extends Component
     public $type = '';
 
     public $editingBin = null;
-
-    public $perPage = 10;
-    public $search = '';
-    public $sortBy = '';
-    public $sortDirection = 'desc';
 
     #[Layout('layouts.app')]
     public function render()
@@ -81,17 +78,5 @@ class Bins extends Component
         $this->reset(['name', 'location_id', 'type']);
         unset($this->bins);
         $this->modal('bin-form')->close();
-    }
-
-    public function sort($column)
-    {
-        if ($this->sortBy === $column && $this->sortDirection === 'asc') {
-            $this->reset('sortBy', 'sortDirection');
-        } elseif ($this->sortBy === $column) {
-            $this->sortDirection = 'asc';
-        } else {
-            $this->sortBy = $column;
-            $this->sortDirection = 'desc';
-        }
     }
 }

--- a/app/Livewire/Pages/Inventory/Locations.php
+++ b/app/Livewire/Pages/Inventory/Locations.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Pages\Inventory;
 
+use App\Livewire\Concerns\WithDataTable;
 use App\Models\Bin;
 use App\Models\Location;
 use App\Models\Thing;
@@ -13,16 +14,12 @@ use Livewire\WithPagination;
 
 class Locations extends Component
 {
+    use WithDataTable;
     use WithPagination;
 
     #[Validate('required|min:3')]
     public $name = '';
     public $editingLocation = null;
-
-    public $perPage = 10;
-    public $search = '';
-    public $sortBy = '';
-    public $sortDirection = 'desc';
 
     #[Layout('layouts.app')]
     public function render()
@@ -71,17 +68,5 @@ class Locations extends Component
         $this->reset('name');
         unset($this->locations);
         $this->modal('location-form')->close();
-    }
-
-    public function sort($column)
-    {
-        if ($this->sortBy === $column && $this->sortDirection === 'asc') {
-            $this->reset('sortBy', 'sortDirection');
-        } elseif ($this->sortBy === $column) {
-            $this->sortDirection = 'asc';
-        } else {
-            $this->sortBy = $column;
-            $this->sortDirection = 'desc';
-        }
     }
 }

--- a/app/Livewire/Pages/Inventory/Things.php
+++ b/app/Livewire/Pages/Inventory/Things.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Pages\Inventory;
 
+use App\Livewire\Concerns\WithDataTable;
 use App\Models\Bin;
 use App\Models\Location;
 use App\Models\Thing;
@@ -13,6 +14,7 @@ use Livewire\WithPagination;
 
 class Things extends Component
 {
+    use WithDataTable;
     use WithPagination;
 
     #[Validate('required|min:3')]
@@ -25,11 +27,6 @@ class Things extends Component
     public $location_id = '';
 
     public $editingThing = null;
-
-    public $perPage = 10;
-    public $search = '';
-    public $sortBy = '';
-    public $sortDirection = 'desc';
 
     #[Layout('layouts.app')]
     public function render()
@@ -91,17 +88,5 @@ class Things extends Component
         $this->reset(['name', 'bin_id', 'location_id']);
         unset($this->things);
         $this->modal('thing-form')->close();
-    }
-
-    public function sort($column)
-    {
-        if ($this->sortBy === $column && $this->sortDirection === 'asc') {
-            $this->reset('sortBy', 'sortDirection');
-        } elseif ($this->sortBy === $column) {
-            $this->sortDirection = 'asc';
-        } else {
-            $this->sortBy = $column;
-            $this->sortDirection = 'desc';
-        }
     }
 }

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -31,6 +31,24 @@ test('email can be verified', function () {
     $response->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
 });
 
+test('redirected if already verified', function () {
+    $user = User::factory()->create();
+
+    Event::fake();
+
+    $verificationUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1($user->email)]
+    );
+
+    $response = $this->actingAs($user)->get($verificationUrl);
+
+    Event::assertNotDispatched(Verified::class);
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
+    $response->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
+});
+
 test('email is not verified with invalid hash', function () {
     $user = User::factory()->unverified()->create();
 


### PR DESCRIPTION
This moves the duplicated sort function and the table's public properties to a trait. Further refinement could be done since the actual sorting/searching queries are duplicated (see below).

```php
->when($this->sortBy, fn ($query) => $query->orderBy($this->sortBy, $this->sortDirection))
->when($this->search, fn ($query) => $query->where('name', 'like', '%' . $this->search . '%'))
```