### PR TITLE
Add ability to edit user's status

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'status',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__ . '/../routes/web.php',
+        api: __DIR__ . '/../routes/api.php',
         commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.9",
+        "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
         "livewire/flux": "^1.0",
         "livewire/flux-pro": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "778efc9f725f687aa43126054b5a8337",
+    "content-hash": "33cf70b87d9f337597af431b69bb2d6c",
     "packages": [
         {
             "name": "brick/math",
@@ -1321,6 +1321,70 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.0"
             },
             "time": "2024-09-30T14:27:51+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "54aea9d13743ae8a6cdd3c28dbef128a17adecab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/54aea9d13743ae8a6cdd3c28dbef128a17adecab",
+                "reference": "54aea9d13743ae8a6cdd3c28dbef128a17adecab",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0",
+                "illuminate/contracts": "^11.0",
+                "illuminate/database": "^11.0",
+                "illuminate/support": "^11.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2024-09-27T14:55:41+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,83 @@
+<?php
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort()
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+    ],
+
+];

--- a/database/migrations/2024_10_12_203117_add_status_to_users.php
+++ b/database/migrations/2024_10_12_203117_add_status_to_users.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('status')->after('email')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/database/migrations/2024_10_12_204214_create_personal_access_tokens_table.php
+++ b/database/migrations/2024_10_12_204214_create_personal_access_tokens_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/resources/views/livewire/pages/users.blade.php
+++ b/resources/views/livewire/pages/users.blade.php
@@ -14,6 +14,7 @@ state([
     'editingUser',
     'name' => '',
     'email' => '',
+    'status' => '',
 ]);
 
 $delete = function ($id) {
@@ -28,6 +29,7 @@ $edit = function ($id) {
     $this->editingUser = $user;
     $this->name = $user->name;
     $this->email = $user->email;
+    $this->status = $user->status;
 
     $this->modal('edit-user')->show();
 };
@@ -36,6 +38,7 @@ $save = function () {
     $validated = $this->validate([
         'name' => ['required', 'string', 'max:255'],
         'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->editingUser->id)],
+        'status' => ['nullable', 'string'],
     ]);
 
     $this->editingUser->fill($validated);
@@ -46,7 +49,7 @@ $save = function () {
 
     $this->editingUser->save();
 
-    $this->reset('editingUser', 'name', 'email');
+    $this->reset('editingUser', 'name', 'email', 'status');
     $this->modal('edit-user')->close();
 };
 
@@ -77,6 +80,7 @@ $users = computed(function () {
             <flux:column>ID</flux:column>
             <flux:column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:column>
             <flux:column sortable :sorted="$sortBy === 'email'" :direction="$sortDirection" wire:click="sort('email')">Email</flux:column>
+            <flux:column sortable :sorted="$sortBy === 'status'" :direction="$sortDirection" wire:click="sort('status')">Status</flux:column>
         </flux:columns>
 
         <flux:rows>
@@ -85,6 +89,7 @@ $users = computed(function () {
                     <flux:cell>{{ $user->id }}</flux:cell>
                     <flux:cell>{{ $user->name }}</flux:cell>
                     <flux:cell>{{ $user->email }}</flux:cell>
+                    <flux:cell>{{ $user->status }}</flux:cell>
 
                     <flux:cell>
                         <flux:dropdown>
@@ -110,6 +115,7 @@ $users = computed(function () {
 
             <flux:input wire:model="name" :label="__('Name')" type="text" required autocomplete="name" />
             <flux:input wire:model="email" :label="__('Email')" type="email" required autocomplete="email" />
+            <flux:input wire:model="status" :label="__('Status')" type="text" clearable />
 
             <div class="flex">
                 <flux:spacer />

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::get('user', function (Request $request) {
+    return $request->user();
+})->middleware('auth:sanctum');

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,3 +6,15 @@ use Illuminate\Support\Facades\Route;
 Route::get('user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+
+Route::post('user/status', function (Request $request) {
+    $data = $request->validate([
+        'status' => 'required',
+    ]);
+
+    $request->user()->update(['status' => $data['status']]);
+})->middleware('auth:sanctum');
+
+Route::delete('user/status', function (Request $request) {
+    $request->user()->update(['status' => null]);
+})->middleware('auth:sanctum');

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,17 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote')->hourly();
+
+Artisan::command('app:clear-status', function () {
+    $twoHoursAgo = now()->subHours(2);
+
+    User::whereNotNull('status')
+        ->where('updated_at', '<=', $twoHoursAgo)
+        ->update(['status' => null]);
+})->purpose('Clear stale statuses')->everyMinute();

--- a/tests/Feature/Api/UserStatusTest.php
+++ b/tests/Feature/Api/UserStatusTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\User;
+
+test('can add status of user', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson('/api/user/status', [
+            'status' => 'pairing',
+        ])
+        ->assertStatus(200);
+
+    expect($user->fresh()->status)->toBe('pairing');
+});
+
+test('can change status of user', function () {
+    $user = User::factory()->create(['status' => 'meeting']);
+
+    $this->actingAs($user)
+        ->postJson('/api/user/status', [
+            'status' => 'pairing',
+        ])
+        ->assertStatus(200);
+
+    expect($user->fresh()->status)->toBe('pairing');
+});
+
+test('status is required', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson('/api/user/status', [
+            // 'status' => 'pairing',
+        ])
+        ->assertJsonValidationErrorFor('status');
+
+    expect($user->fresh()->status)->not->toBe('pairing');
+});
+
+test('status can be cleared', function () {
+    $user = User::factory()->create(['status' => 'pairing']);
+
+    $this->actingAs($user)
+        ->deleteJson('/api/user/status')
+        ->assertOk();
+
+    expect($user->fresh()->status)->toBeNull();
+});

--- a/tests/Feature/Commands/ClearStatusTest.php
+++ b/tests/Feature/Commands/ClearStatusTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+test('user status is cleared after two hours of inactivity', function () {
+    $user = User::factory()->create(['status' => 'pairing']);
+
+    Carbon::setTestNow(now()->addHours(2));
+
+    $this->artisan('app:clear-status');
+
+    expect($user->fresh()->status)->toBeNull();
+});
+
+test('user status is cleared after more than two hours of inactivity', function () {
+    $user = User::factory()->create(['status' => 'pairing']);
+
+    Carbon::setTestNow(now()->addHours(2)->addMinute());
+
+    $this->artisan('app:clear-status');
+
+    expect($user->fresh()->status)->toBeNull();
+});
+
+test('user status is not cleared before two hours of inactivity', function () {
+    $user = User::factory()->create(['status' => 'pairing']);
+
+    Carbon::setTestNow(now()->addHour());
+
+    $this->artisan('app:clear-status');
+
+    expect($user->fresh()->status)->toBe('pairing');
+});
+
+test('does not update null status', function () {
+    $user = User::factory()->create(['status' => null]);
+    $oldUpdatedAt = $user->updated_at->toDateTimeString();
+
+    Carbon::setTestNow(now()->addHours(2));
+
+    $this->artisan('app:clear-status');
+
+    expect($user->fresh()->updated_at->toDateTimeString())->toBe($oldUpdatedAt);
+});

--- a/tests/Feature/Livewire/Pages/UsersTest.php
+++ b/tests/Feature/Livewire/Pages/UsersTest.php
@@ -73,3 +73,53 @@ test('can delete user', function () {
         'email' => 'oden@whitebeard.pirate',
     ]);
 });
+
+test('can set status', function () {
+    $user = User::factory()->create([
+        'name' => 'Kouzuki Oden',
+        'email' => 'oden@whitebeard.pirate',
+    ]);
+
+    Volt::test('pages.users')
+        ->call('edit', $user->id)
+        ->assertSet('name', 'Kouzuki Oden')
+        ->assertSet('email', 'oden@whitebeard.pirate')
+        ->set('status', 'Eating Oden')
+        ->call('save');
+
+    expect($user->fresh()->status)->toBe('Eating Oden');
+});
+
+test('can clear status', function () {
+    $user = User::factory()->create([
+        'name' => 'Kouzuki Oden',
+        'email' => 'oden@whitebeard.pirate',
+        'status' => 'Eating Oden',
+    ]);
+
+    Volt::test('pages.users')
+        ->call('edit', $user->id)
+        ->assertSet('name', 'Kouzuki Oden')
+        ->assertSet('email', 'oden@whitebeard.pirate')
+        ->set('status', '')
+        ->call('save');
+
+    expect($user->fresh()->status)->toBe('');
+});
+
+test('can change status', function () {
+    $user = User::factory()->create([
+        'name' => 'Kouzuki Oden',
+        'email' => 'oden@whitebeard.pirate',
+        'status' => 'Eating Oden',
+    ]);
+
+    Volt::test('pages.users')
+        ->call('edit', $user->id)
+        ->assertSet('name', 'Kouzuki Oden')
+        ->assertSet('email', 'oden@whitebeard.pirate')
+        ->set('status', 'Fighting')
+        ->call('save');
+
+    expect($user->fresh()->status)->toBe('Fighting');
+});


### PR DESCRIPTION
Closes #6 

This PR:
- Adds status column to `users` table
- Adds the ability to edit user status from the users' page
- Adds the ability to edit user status from an API endpoint
- Automatically clears after 2 hours