### PR TITLE
Status Lists

### DIFF
--- a/app/Livewire/Forms/UserForm.php
+++ b/app/Livewire/Forms/UserForm.php
@@ -10,7 +10,6 @@ class UserForm extends Form
 {
     public $name = '';
     public $email = '';
-    public $status = '';
     public $status_list = [];
 
     public $editingUser = null;
@@ -20,17 +19,12 @@ class UserForm extends Form
         $this->editingUser = $user;
         $this->name = $user->name;
         $this->email = $user->email;
-        $this->status = $user->status;
         $this->status_list = $user->status_list ?? [['emoji' => '🙂', 'status' => '']];
     }
 
     public function update(): void
     {
         $validated = $this->validate();
-
-        if ($validated['status'] === '') {
-            $validated['status'] = null;
-        }
 
         $this->editingUser->fill($validated);
 
@@ -48,7 +42,6 @@ class UserForm extends Form
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->editingUser->id)],
-            'status' => ['nullable'],
             'status_list' => ['nullable', 'array'],
         ];
     }

--- a/app/Livewire/Forms/UserForm.php
+++ b/app/Livewire/Forms/UserForm.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Livewire\Forms;
+
+use App\Models\User;
+use Illuminate\Validation\Rule;
+use Livewire\Form;
+
+class UserForm extends Form
+{
+    public $name = '';
+    public $email = '';
+    public $status = '';
+    public $status_list = [];
+
+    public $editingUser = null;
+
+    public function setUser(User $user): void
+    {
+        $this->editingUser = $user;
+        $this->name = $user->name;
+        $this->email = $user->email;
+        $this->status = $user->status;
+        $this->status_list = $user->status_list ?? [['emoji' => '🙂', 'status' => '']];
+    }
+
+    public function update(): void
+    {
+        $validated = $this->validate();
+
+        if ($validated['status'] === '') {
+            $validated['status'] = null;
+        }
+
+        $this->editingUser->fill($validated);
+
+        if ($this->editingUser->isDirty('email')) {
+            $this->editingUser->email_verified_at = null;
+        }
+
+        $this->editingUser->save();
+
+        $this->reset();
+    }
+
+    protected function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->editingUser->id)],
+            'status' => ['nullable'],
+            'status_list' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Livewire/Pages/Users.php
+++ b/app/Livewire/Pages/Users.php
@@ -20,6 +20,9 @@ class Users extends Component
 
     public $apiToken;
 
+    public $status = ['emoji' => '🙂', 'text' => ''];
+    public $setStatusFor;
+
     #[Layout('layouts.app')]
     public function render()
     {
@@ -29,6 +32,12 @@ class Users extends Component
     public function addStatusToList()
     {
         $this->form->status_list[] = ['emoji' => '🙂', 'status' => ''];
+    }
+
+    public function clearStatus($id)
+    {
+        User::find($id)->update(['status' => null]);
+        unset($this->users);
     }
 
     public function closeApiToken()
@@ -56,6 +65,21 @@ class Users extends Component
         $this->apiToken = $user->createToken('Sunny')->plainTextToken;
 
         $this->modal('api-token')->show();
+    }
+
+    public function setStatus()
+    {
+        $this->setStatusFor->update([
+            'status' => is_string($this->status) ? $this->status : $this->status['emoji'] . ' - ' . $this->status['text'],
+        ]);
+        $this->reset(['status', 'setStatusFor']);
+        $this->modal('set-status')->close();
+    }
+
+    public function showStatusModal($id)
+    {
+        $this->setStatusFor = User::find($id);
+        $this->modal('set-status')->show();
     }
 
     public function removeStatusFromList($index)

--- a/app/Livewire/Pages/Users.php
+++ b/app/Livewire/Pages/Users.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Livewire\Pages;
+
+use App\Livewire\Concerns\WithDataTable;
+use App\Livewire\Forms\UserForm;
+use App\Models\User;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Users extends Component
+{
+    use WithDataTable;
+    use WithPagination;
+
+    public UserForm $form;
+
+    public $apiToken;
+
+    #[Layout('layouts.app')]
+    public function render()
+    {
+        return view('livewire.pages.users');
+    }
+
+    public function addStatusToList()
+    {
+        $this->form->status_list[] = ['emoji' => '🙂', 'status' => ''];
+    }
+
+    public function closeApiToken()
+    {
+        $this->modal('api-token')->close();
+        $this->reset(['apiToken']);
+    }
+
+    public function delete($id)
+    {
+        User::find($id)->delete();
+        unset($this->users);
+    }
+
+    public function edit($id)
+    {
+        $user = User::find($id);
+        $this->form->setUser($user);
+        $this->modal('edit-user')->show();
+    }
+
+    public function getToken($id)
+    {
+        $user = User::find($id);
+        $this->apiToken = $user->createToken('Sunny')->plainTextToken;
+
+        $this->model('api-token')->show();
+    }
+
+    public function removeStatusFromList($index)
+    {
+        unset($this->form->status_list[$index]);
+        $this->form->status_list = array_values($this->form->status_list);
+    }
+
+    public function save()
+    {
+        $this->form->update();
+        $this->modal('edit-user')->close();
+    }
+
+    #[Computed]
+    public function users(): LengthAwarePaginator
+    {
+        return User::query()
+            ->when($this->sortBy, fn ($query) => $query->orderBy($this->sortBy, $this->sortDirection))
+            ->when($this->search, fn ($query) => $query->where('name', 'like', '%' . $this->search . '%'))
+            ->paginate($this->perPage);
+    }
+}

--- a/app/Livewire/Pages/Users.php
+++ b/app/Livewire/Pages/Users.php
@@ -55,7 +55,7 @@ class Users extends Component
         $user = User::find($id);
         $this->apiToken = $user->createToken('Sunny')->plainTextToken;
 
-        $this->model('api-token')->show();
+        $this->modal('api-token')->show();
     }
 
     public function removeStatusFromList($index)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'email',
         'password',
         'status',
+        'status_list'
     ];
 
     /**
@@ -40,6 +41,7 @@ class User extends Authenticatable implements MustVerifyEmail
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'status_list' => 'array',
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,7 +22,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'email',
         'password',
         'status',
-        'status_list'
+        'status_list',
     ];
 
     /**

--- a/database/migrations/2024_12_07_022652_add_status_list_to_user.php
+++ b/database/migrations/2024_12_07_022652_add_status_list_to_user.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->json('status_list')->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('status_list');
+        });
+    }
+};

--- a/resources/views/components/status.blade.php
+++ b/resources/views/components/status.blade.php
@@ -1,0 +1,19 @@
+<div x-data="{
+    status: $wire.entangle('{{ $attributes->get('wire:model') }}'),
+    select($event) {
+        this.status.emoji = $event.detail.unicode;
+        $el.click();
+    }
+    }">
+    <flux:input.group>
+        <flux:dropdown>
+            <flux:button x-text="status.emoji"></flux:button>
+
+            <flux:menu>
+                <emoji-picker x-on:emoji-click="select($event)"></emoji-picker>
+            </flux:menu>
+        </flux:dropdown>
+
+        <flux:input x-model="status.text" placeholder="Doing or Feeling" />
+    </flux:input.group>
+</div>

--- a/resources/views/livewire/pages/users.blade.php
+++ b/resources/views/livewire/pages/users.blade.php
@@ -29,7 +29,18 @@
                 <flux:cell>{{ $user->id }}</flux:cell>
                 <flux:cell>{{ $user->name }}</flux:cell>
                 <flux:cell>{{ $user->email }}</flux:cell>
-                <flux:cell>{{ $user->status }}</flux:cell>
+                <flux:cell>
+                    @if ($user->status)
+                    <div class="flex space-x-2">
+                        <div>{{ $user->status }}</div>
+                        <flux:button icon="x-mark" size="xs" variant="subtle" wire:click="clearStatus({{ $user->id }})" />
+                    </div>
+                    @else
+                    <flux:button variant="subtle" size="xs" wire:click="showStatusModal({{ $user->id }})">
+                        Set Status
+                    </flux:button>
+                    @endif
+                </flux:cell>
 
                 <flux:cell>
                     <flux:dropdown>
@@ -57,7 +68,6 @@
 
             <flux:input wire:model="form.name" :label="__('Name')" type="text" required autocomplete="name" />
             <flux:input wire:model="form.email" :label="__('Email')" type="email" required autocomplete="email" />
-            <flux:input wire:model="form.status" :label="__('Current Status')" type="text" clearable />
 
             <flux:field>
                 <flux:label>Status List</flux:label>
@@ -96,5 +106,27 @@
 
             <flux:button wire:click="closeApiToken" variant="primary">Close</flux:button>
         </div>
+    </flux:modal>
+
+    <flux:modal name="set-status">
+        <form wire:submit="setStatus" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Set Status</flux:heading>
+            </div>
+
+            <x-status wire:model="status"  />
+
+            <flux:radio.group wire:model="status" label="Or Select Predifined Status">
+                @foreach ($setStatusFor->status_list ?? [] as $index => $item)
+                <flux:radio value="{{ $item['emoji'] }} - {{ $item['text'] }}" label="{{ $item['emoji'] }} - {{ $item['text'] }}" />
+                @endforeach
+            </flux:radio.group>
+
+            <div class="flex">
+                <flux:spacer />
+
+                <flux:button type="submit" variant="primary">Save changes</flux:button>
+            </div>
+        </form>
     </flux:modal>
 </flux:main>

--- a/resources/views/livewire/pages/users.blade.php
+++ b/resources/views/livewire/pages/users.blade.php
@@ -1,113 +1,21 @@
-<?php
-
-use App\Models\User;
-use Illuminate\Validation\Rule;
-
-use function Livewire\Volt\{computed, layout, state, usesPagination};
-
-layout('layouts.app');
-usesPagination();
-
-state([
-    'sortBy',
-    'sortDirection' => 'desc',
-    'editingUser',
-    'name' => '',
-    'email' => '',
-    'status' => '',
-    'apiToken' => '',
-    'status_list' => [],
-]);
-
-$addStatusToList = function () {
-    $this->status_list[] = ['emoji' => '🙂', 'status' => ''];
-};
-
-$closeApiToken = function () {
-    $this->modal('api-token')->close();
-    $this->reset(['apiToken']);
-};
-
-$delete = function ($id) {
-    $this->users->firstWhere('id', $id)->delete();
-
-    unset($this->users);
-};
-
-$edit = function ($id) {
-    $user = $this->users->firstWhere('id', $id);
-
-    $this->editingUser = $user;
-    $this->name = $user->name;
-    $this->email = $user->email;
-    $this->status = $user->status;
-    $this->status_list = $user->status_list ?? [['emoji' => '🙂', 'status' => '']];
-
-    $this->modal('edit-user')->show();
-};
-
-$getToken = function ($id) {
-    $user = $this->users->firstWhere('id', $id);
-    $this->apiToken = $user->createToken('Sunny')->plainTextToken;
-
-    $this->modal('api-token')->show();
-};
-
-$removeStatusFromList = function ($index) {
-    unset($this->status_list[$index]);
-    $this->status_list = array_values($this->status_list);
-};
-
-$save = function () {
-    $validated = $this->validate([
-        'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->editingUser->id)],
-        'status' => ['nullable'],
-        'status_list' => ['nullable', 'array'],
-    ]);
-
-    if ($validated['status'] === '') {
-        $validated['status'] = null;
-    }
-
-    $this->editingUser->fill($validated);
-
-    if ($this->editingUser->isDirty('email')) {
-        $this->editingUser->email_verified_at = null;
-    }
-
-    $this->editingUser->save();
-
-    $this->reset('editingUser', 'name', 'email', 'status');
-    $this->modal('edit-user')->close();
-};
-
-$sort = function ($column) {
-    if ($this->sortBy === $column && $this->sortDirection === 'asc') {
-        $this->reset('sortBy', 'sortDirection');
-    } else if ($this->sortBy === $column) {
-        $this->sortDirection = 'asc';
-    } else {
-        $this->sortBy = $column;
-        $this->sortDirection = 'desc';
-    }
-};
-
-$users = computed(function () {
-    return User::query()
-        ->tap(fn($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
-        ->paginate(10);
-})
-
-?>
-
 @push('head')
 <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1/index.js"></script>
 @endpush
 <flux:main class="space-y-6">
     <flux:heading size="xl" level="1">{{ __('Users') }}</flux:heading>
 
-    <flux:table :paginate="$this->users">
+    <section>
+        <div class="flex justify-between gap-8 mb-2">
+            <flux:input size="sm" wire:model.live="search" icon="magnifying-glass" class="max-w-sm" placeholder="Search tiles" />
+
+            <flux:select size="sm" wire:model.blur="perPage" class="max-w-20" placeholder="Per Page">
+                <flux:option>5</flux:option>
+                <flux:option>10</flux:option>
+                <flux:option>25</flux:option>
+                <flux:option>50</flux:option>
+            </flux:select>
+        </div>
+        <flux:table :paginate="$this->users">
         <flux:columns>
             <flux:column>ID</flux:column>
             <flux:column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:column>
@@ -138,6 +46,7 @@ $users = computed(function () {
             @endforeach
         </flux:rows>
     </flux:table>
+    </section>
 
     <flux:modal name="edit-user" variant="flyout">
         <form wire:submit="save" class="space-y-6">
@@ -146,24 +55,24 @@ $users = computed(function () {
                 <flux:subheading>Make changes to a user's details.</flux:subheading>
             </div>
 
-            <flux:input wire:model="name" :label="__('Name')" type="text" required autocomplete="name" />
-            <flux:input wire:model="email" :label="__('Email')" type="email" required autocomplete="email" />
-            <flux:input wire:model="status" :label="__('Current Status')" type="text" clearable />
+            <flux:input wire:model="form.name" :label="__('Name')" type="text" required autocomplete="name" />
+            <flux:input wire:model="form.email" :label="__('Email')" type="email" required autocomplete="email" />
+            <flux:input wire:model="form.status" :label="__('Current Status')" type="text" clearable />
 
             <flux:field>
                 <flux:label>Status List</flux:label>
 
                 <div class="space-y-2">
-                    @foreach ($status_list as $index => $item)
+                    @foreach ($form->status_list as $index => $item)
                     <div class="flex space-x-2">
-                        <x-status wire:model="status_list.{{ $index }}" />
+                        <x-status wire:model="form.status_list.{{ $index }}" />
                         <flux:button variant="subtle" icon="x-mark" wire:click="removeStatusFromList({{ $index }})"/>
                     </div>
                     @endforeach
                     <flux:button size="xs" wire:click="addStatusToList">Add Status</flux:button>
                 </div>
 
-                <flux:error name="status_list" />
+                <flux:error name="form.status_list" />
             </flux:field>
 
             <div class="flex">

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,11 @@ Route::get('user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
+Route::get('user/status', function (Request $request) {
+    return collect($request->user()->status_list)
+        ->map(fn ($item) => $item['emoji'] . ' - ' . $item['text']);
+})->middleware('auth:sanctum');
+
 Route::post('user/status', function (Request $request) {
     $data = $request->validate([
         'status' => 'required',

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,8 +5,8 @@ use App\Livewire\Pages\Inventory\Bins;
 use App\Livewire\Pages\Inventory\Locations;
 use App\Livewire\Pages\Inventory\Things;
 use App\Livewire\Pages\LogPose\Tiles;
+use App\Livewire\Pages\Users;
 use Illuminate\Support\Facades\Route;
-use Livewire\Volt\Volt;
 
 Route::view('/', 'welcome');
 
@@ -32,7 +32,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('log-pose/tiles', Tiles::class)->name('log-pose.tiles');
 
-    Volt::route('/users', 'pages.users')->name('users');
+    Route::get('users', Users::class)->name('users');
 });
 
 require __DIR__ . '/auth.php';

--- a/tests/Feature/Api/UserStatusTest.php
+++ b/tests/Feature/Api/UserStatusTest.php
@@ -8,7 +8,7 @@ test('can get list of user statuses', function () {
             ['emoji' => '🍢', 'text' => 'Eating Oden'],
             ['emoji' => '🥋', 'text' => 'Fighting'],
             ['emoji' => '🕺🏻', 'text' => 'Dancing'],
-        ]
+        ],
     ]);
 
     $this->actingAs($user)
@@ -19,7 +19,7 @@ test('can get list of user statuses', function () {
         ->assertJson([
             '🍢 - Eating Oden',
             '🥋 - Fighting',
-            '🕺🏻 - Dancing'
+            '🕺🏻 - Dancing',
         ]);
 });
 

--- a/tests/Feature/Api/UserStatusTest.php
+++ b/tests/Feature/Api/UserStatusTest.php
@@ -2,6 +2,27 @@
 
 use App\Models\User;
 
+test('can get list of user statuses', function () {
+    $user = User::factory()->create([
+        'status_list' => [
+            ['emoji' => '🍢', 'text' => 'Eating Oden'],
+            ['emoji' => '🥋', 'text' => 'Fighting'],
+            ['emoji' => '🕺🏻', 'text' => 'Dancing'],
+        ]
+    ]);
+
+    $this->actingAs($user)
+        ->getJson('/api/user/status', [
+            'status' => 'pairing',
+        ])
+        ->assertStatus(200)
+        ->assertJson([
+            '🍢 - Eating Oden',
+            '🥋 - Fighting',
+            '🕺🏻 - Dancing'
+        ]);
+});
+
 test('can add status of user', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Livewire/LogPose/TilesTest.php
+++ b/tests/Feature/Livewire/LogPose/TilesTest.php
@@ -58,7 +58,7 @@ test('can edit tile', function () {
 test('can delete tile', function () {
     $tile = Tile::factory()->create([
         'name' => 'oden',
-        'type' => 'calendar'
+        'type' => 'calendar',
     ]);
 
     Livewire::test(Tiles::class)

--- a/tests/Feature/Livewire/Pages/UsersTest.php
+++ b/tests/Feature/Livewire/Pages/UsersTest.php
@@ -197,3 +197,12 @@ test('can remove status from status list', function () {
         ->assertSet('form.status_list.1.emoji', '🧑🏻‍💻')
         ->assertSet('form.status_list.1.status', 'Coding - Sunny');
 });
+
+test('api token reset on close', function () {
+    $user = User::factory()->create();
+
+    Livewire::test(Users::class)
+        ->call('getToken', $user->id)
+        ->call('closeApiToken')
+        ->assertSet('apiToken', null);
+});

--- a/tests/Feature/Livewire/Pages/UsersTest.php
+++ b/tests/Feature/Livewire/Pages/UsersTest.php
@@ -158,7 +158,7 @@ describe('set status modal', function () {
                 ['emoji' => '🍢', 'text' => 'Eating Oden'],
                 ['emoji' => '🥋', 'text' => 'Fighting'],
                 ['emoji' => '🕺🏻', 'text' => 'Dancing'],
-            ]
+            ],
         ]);
 
         Livewire::test(Users::class)


### PR DESCRIPTION
This PR adds:
- Converts users page from volt to livewire component
- Users can add predefined statuses
- Set status with emoji picker
- Set status from predefined list
- API endpoint for receiving list of statuses